### PR TITLE
인트로 페이지 채팅창 글자 깜빡이던 현상 수정

### DIFF
--- a/js/intro.js
+++ b/js/intro.js
@@ -69,6 +69,5 @@ const app = new Vue({
     }
   },
   mounted() {
-    this.activeChat();
   }
 })


### PR DESCRIPTION
Resolved #17 

- 원인 : mounted 시점과 이미지 로드 시점 동시에 두 번의 activeChat 함수가 실행됐기 때문.
- 해결 : 인트로 페이지에서 mounted 시점에 실행되던 activeChat 함수를 실행되지 않도록 호출 코드를 지움.